### PR TITLE
Fix 'jaggies' (antialiasing on rotated elements) in firefox

### DIFF
--- a/oridomi.coffee
+++ b/oridomi.coffee
@@ -348,6 +348,7 @@ do ->
     position:           'absolute'
     overflow:           'hidden'
     transform:          'translate3d(0, 0, 0)'
+    outline:            '1px solid transparent'
 
   addStyle elClasses.panel,
     width:              '100%'


### PR DESCRIPTION
A workaround to prevent 'jaggies' appearing on element edges due to lack of antialiasing on rotated elements in firefox.
